### PR TITLE
Add Render-Only Pattern Config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ root. Available configuration options:
 - `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
 - `cacheConfig` - an object array to specify caching options
 - `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
+- `renderOnlyPattern` - similar to `renderOnly` but uses a regex instead of a strict prefix match. eg. `"^https://.*mysite.com.*"`
 - `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 - `restrictedUrlPattern`_default `null`_ - set the restrictedUrlPattern to restrict the requests matching given regex pattern.
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -11,6 +11,7 @@ root. Available configuration options:
 - `cache` _default `null`_ - set to `datastore` to enable caching on Google Cloud using datastore _only use if deploying to google cloud_, `memory` to enable in-memory caching or `filesystem` to enable disk based caching
 - `cacheConfig` - an object array to specify caching options
 - `renderOnly` - restrict the endpoint to only service requests for certain domains. Specified as an array of strings. eg. `['http://render.only.this.domain']`. This is a strict prefix match, so ensure you specify the exact protocols that will be used (eg. http, https).
+- `renderOnlyPattern` - similar to `renderOnly` but uses a regex instead of a strict prefix match. eg. `"^https://.*mysite.com.*"`
 - `closeBrowser`_default `false`_ - `true` forces the browser to close and reopen between each page render, some sites might need this to prevent URLs past the first one rendered returning null responses.
 
 ## cacheConfig

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "rendertron",
-  "version": "3.1.0",
+  "name": "@internetarchive/rendertron",
+  "version": "3.2.0-alpha.2",
   "description": "Renders webpages using headless Chrome for usage by bots",
   "license": "Apache-2.0",
   "repository": "https://github.com/GoogleChrome/rendertron",
   "engines": {
     "node": ">=10"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "main": "build/rendertron.js",
   "types": "build/rendertron.d.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,7 @@ export type Config = {
   headers: { [key: string]: string };
   puppeteerArgs: Array<string>;
   renderOnly: Array<string>;
+  renderOnlyPattern: string | null;
   closeBrowser: boolean;
   restrictedUrlPattern: string | null;
 };
@@ -58,6 +59,7 @@ export class ConfigManager {
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
+    renderOnlyPattern: null,
     closeBrowser: false,
     restrictedUrlPattern: null
   };

--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -125,12 +125,21 @@ export class Rendertron {
       return true;
     }
 
-    if (!this.config.renderOnly.length) {
+    // if we don't have any renderOnly urls or a renderOnlyPattern, there
+    // are no restrictions
+    if (!(this.config.renderOnly.length || this.config.renderOnlyPattern)) {
       return false;
     }
 
     for (let i = 0; i < this.config.renderOnly.length; i++) {
       if (href.startsWith(this.config.renderOnly[i])) {
+        return false;
+      }
+    }
+
+    if (this.config.renderOnlyPattern) {
+      const matches = href.match(new RegExp(this.config.renderOnlyPattern));
+      if (matches) {
         return false;
       }
     }

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -281,7 +281,7 @@ test('whitelist regex pattern ensures other urls do not get rendered', async (t:
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
-    renderOnlyPattern: '.*localhost.*',
+    renderOnlyPattern: 'http://localhost.*',
     closeBrowser: false,
     restrictedUrlPattern: null,
   };

--- a/src/test/app-test.ts
+++ b/src/test/app-test.ts
@@ -252,6 +252,36 @@ test('whitelist ensures other urls do not get rendered', async (t: ExecutionCont
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [testBase],
+    renderOnlyPattern: null,
+    closeBrowser: false,
+    restrictedUrlPattern: null,
+  };
+  const server = request(await new Rendertron().initialize(mockConfig));
+
+  let res = await server.get(`/render/${testBase}basic-script.html`);
+  t.is(res.status, 200);
+
+  res = await server.get(`/render/http://anotherDomain.com`);
+  t.is(res.status, 403);
+});
+
+test('whitelist regex pattern ensures other urls do not get rendered', async (t: ExecutionContext) => {
+  const mockConfig = {
+    cache: 'memory' as const,
+    cacheConfig: {
+      cacheDurationMinutes: '120',
+      cacheMaxEntries: '50',
+    },
+    timeout: 10000,
+    port: '3000',
+    host: '0.0.0.0',
+    width: 1000,
+    height: 1000,
+    reqHeaders: {},
+    headers: {},
+    puppeteerArgs: ['--no-sandbox'],
+    renderOnly: [],
+    renderOnlyPattern: '.*localhost.*',
     closeBrowser: false,
     restrictedUrlPattern: null,
   };
@@ -285,6 +315,7 @@ test('endpont for invalidating memory cache works if configured', async (t: Exec
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
+    renderOnlyPattern: null,
     closeBrowser: false,
     restrictedUrlPattern: null,
   };
@@ -331,6 +362,7 @@ test('endpont for invalidating filesystem cache works if configured', async (t: 
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
+    renderOnlyPattern: null,
     closeBrowser: false,
     restrictedUrlPattern: null,
   };
@@ -382,6 +414,7 @@ test('http header should be set via config', async (t: ExecutionContext) => {
     headers: {},
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
+    renderOnlyPattern: null,
     closeBrowser: false,
     restrictedUrlPattern: null,
   };
@@ -412,6 +445,7 @@ test.serial(
       headers: {},
       puppeteerArgs: ['--no-sandbox'],
       renderOnly: [],
+      renderOnlyPattern: null,
       closeBrowser: false,
       restrictedUrlPattern: null,
     };
@@ -465,6 +499,7 @@ test.serial(
       },
       puppeteerArgs: ['--no-sandbox'],
       renderOnly: [],
+      renderOnlyPattern: null,
       closeBrowser: false,
       restrictedUrlPattern: null,
     };
@@ -544,6 +579,7 @@ test('urls mathing pattern are restricted', async (t) => {
     },
     puppeteerArgs: ['--no-sandbox'],
     renderOnly: [],
+    renderOnlyPattern: null,
     closeBrowser: false,
     restrictedUrlPattern: '.*(\\.test.html)($|\\?)',
   };
@@ -572,4 +608,3 @@ test('urls mathing pattern are restricted', async (t) => {
   await cached_server.get(`/invalidate/`);
   fs.rmdirSync(path.join(os.tmpdir(), 'rendertron-test-cache'));
 });
-

--- a/test-resources/package-lock.json
+++ b/test-resources/package-lock.json
@@ -1,6 +1,19 @@
 {
+  "name": "test-resources",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@webcomponents/webcomponentsjs": "^2.4.0"
+      }
+    },
+    "node_modules/@webcomponents/webcomponentsjs": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.0.tgz",
+      "integrity": "sha512-kEClEz2nu9/i6SvyBJTV4pCc6CyCzMhK7zEeJ6QhiJoulBp4YZ06Zfj2E2HUXfWfHJIjtKriJYMtfhettKEjEg=="
+    }
+  },
   "dependencies": {
     "@webcomponents/webcomponentsjs": {
       "version": "2.4.0",


### PR DESCRIPTION
This allows us to configure a regex to match the host request by instead of a strict prefix-only match